### PR TITLE
Add rust target

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -4,7 +4,7 @@ use paris::{error, info};
 use std::io::Read;
 use std::{fs::File, path::Path};
 
-use ramble::targets::{CodeGenerator, TargetC};
+use ramble::targets::{CodeGenerator, TargetC, TargetRust};
 use ramble::{RambleConfig, Scanner};
 
 #[derive(Parser, Debug)]
@@ -29,6 +29,9 @@ enum Commands {
         #[arg(long = "C")]
         /// Output a C/C++ Library
         target_c: bool,
+        #[arg(long = "rust")]
+        /// Output a Rust Library
+        target_rust: bool,
     },
 }
 
@@ -65,6 +68,7 @@ fn main() -> Result<()> {
             file,
             output_dir,
             target_c,
+            target_rust,
         } => {
             let out_path = match output_dir.as_deref() {
                 Some(o) => Path::new(o),
@@ -83,6 +87,15 @@ fn main() -> Result<()> {
             if target_c {
                 info!("Generating C/C++ Target to {:?}", out_path);
                 let files_written = code_generator.to_code::<TargetC>(&ramble_config)?;
+
+                for file in files_written {
+                    info!("    file written: {:#?}", file);
+                }
+            };
+
+            if target_rust {
+                info!("Generating Rust Target to {:?}", out_path);
+                let files_written = code_generator.to_code::<TargetRust>(&ramble_config)?;
 
                 for file in files_written {
                     info!("    file written: {:#?}", file);

--- a/src/targets/mod.rs
+++ b/src/targets/mod.rs
@@ -1,7 +1,9 @@
 mod generate;
 mod target_c;
+mod target_rust;
 mod utils;
 
 pub use generate::CodeGenerator;
 pub use target_c::TargetC;
+pub use target_rust::TargetRust;
 pub use utils::FileObject;

--- a/src/targets/target_rust.rs
+++ b/src/targets/target_rust.rs
@@ -1,0 +1,58 @@
+use anyhow::Context;
+use convert_case::{Case, Casing};
+use handlebars::handlebars_helper;
+use handlebars::{to_json, Handlebars, RenderErrorReason};
+use serde_json::Map;
+use serde_json::Value;
+use std::path::PathBuf;
+
+use super::generate::Lang;
+use super::FileObject;
+use crate::packet::FieldType;
+use crate::RambleConfig;
+
+handlebars_helper!(upper_camel: |x: str| x.to_case(Case::UpperCamel));
+handlebars_helper!(snake: |x: str| x.to_case(Case::Snake));
+
+handlebars_helper!(map_type: |x: str| {
+    let ty = FieldType::try_from(x).map_err(|e| RenderErrorReason::Other(e.to_string()) )?; // TODO: Improve error handling
+    TargetRust::type_map(&ty).to_string()
+});
+
+pub struct TargetRust {}
+
+impl Lang for TargetRust {
+    fn type_map(ft: &FieldType) -> &str {
+        match ft {
+            FieldType::Uint8T => "u8",
+        }
+    }
+
+    fn render_template(rfg: &RambleConfig) -> anyhow::Result<Vec<FileObject>> {
+        let path = PathBuf::from("src/targets/templates/rust/ramble.rs.hbs");
+
+        let filename = path
+            .file_stem()
+            .context("unable to get filename from path")?
+            .to_os_string();
+
+        let mut handlebars = Handlebars::new();
+        handlebars.register_template_file(
+            "src",
+            path.to_str()
+                .context("Program Error: Check path variable ")?,
+        )?;
+
+        handlebars.register_helper("upper_camel", Box::new(upper_camel));
+        handlebars.register_helper("upper", Box::new(snake));
+        handlebars.register_helper("map_type", Box::new(map_type));
+
+        let mut data = Map::<String, Value>::new();
+        data.insert("packets".into(), to_json(&rfg.messages));
+
+        Ok(vec![FileObject {
+            filename,
+            contents: handlebars.render("src", &data)?,
+        }])
+    }
+}

--- a/src/targets/templates/rust/ramble.rs.hbs
+++ b/src/targets/templates/rust/ramble.rs.hbs
@@ -1,0 +1,156 @@
+///////////////////////////////////////////////
+// This file was generated using Ramble.
+///////////////////////////////////////////////
+use binread::{BinRead, BinReaderExt};
+use binwrite::BinWrite;
+use std::{convert::TryFrom, io::Cursor};
+
+type TagValue = u8;
+
+#[derive(thiserror::Error, Debug)]
+pub enum SerializeError {
+    // #[error("could not serialize `{0}` ")]
+    // BadSerialize(String),
+    #[error("could not serialize with binread ")]
+    Binread(#[from] binread::Error),
+    // #[error("unknown")]
+    // Unknown,
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum DeserializeError {
+    // #[error("could not serialize `{0}` ")]
+    // BadDeserialize(String),
+    #[error("could not deserialize with binread ")]
+    Binwrite(#[from] binread::Error),
+    #[error("unknown type `{0}` ")]
+    UnknownType(i32),
+    // #[error("unknown")]
+    // Unknown,
+}
+
+/* Struct Definitions */
+
+{{#each packets as |pkt|}}
+#[derive(PartialEq, Debug, BinRead, BinWrite)]
+struct {{upper_camel pkt.name}} {
+    {{#each pkt.fields as |field|}}
+    {{field.name}}: {{map_type field.field_type}}, 
+    {{/each}}
+}
+
+{{/each}}
+
+#[derive(Debug)]
+enum MsgTypes {
+    {{#each packets as |pkt|}}
+    {{upper_camel pkt.name}} = {{@index}},
+    {{/each}}
+}
+
+impl MsgTypes {
+    fn get_tag_for(v: &Message) -> TagValue {
+        match v {
+            {{#each packets as |pkt|}}
+            Message::{{upper_camel pkt.name}}(_) => MsgTypes::{{upper_camel pkt.name}} as TagValue,
+            {{/each}}
+        }
+    }
+}
+
+impl TryFrom<TagValue> for MsgTypes {
+    type Error = DeserializeError;
+
+    fn try_from(v: TagValue) -> Result<Self, Self::Error> {
+        match v {
+            {{#each packets as |pkt|}}
+            x if x == Self::{{upper_camel pkt.name}} as TagValue => Ok(Self::{{upper_camel pkt.name}}),
+            {{/each}}
+            _ => Err(DeserializeError::UnknownType(v.into())),
+        }
+    }
+}
+
+
+#[derive(Debug, PartialEq)]
+enum Message {
+    {{#each packets as |pkt|}}
+    {{upper_camel pkt.name}}({{upper_camel pkt.name}}),
+    {{/each}}
+}
+
+impl Message {
+    #![allow(dead_code)]
+    pub fn to_bytes(&self) -> Result<Vec<u8>, SerializeError> {
+        let mut buf = vec![];
+        if let Err(e) = self.write(&mut buf) {
+            return Err(SerializeError::Binread(binread::Error::Io(e)));
+        }
+
+        Ok(buf)
+    }
+
+    pub fn from_bytes(bytes: &[u8]) -> Result<Self, DeserializeError> {
+        let mut reader = Cursor::new(bytes);
+        let m: Message = reader.read_ne()?;
+
+        Ok(m)
+    }
+}
+
+impl BinRead for Message {
+    type Args = ();
+
+    fn read_options<R: std::io::Read + std::io::Seek>(
+        reader: &mut R,
+        options: &binread::ReadOptions,
+        args: Self::Args,
+    ) -> binread::BinResult<Self> {
+        let tag = u8::read_options(reader, options, args)?;
+
+        let msg_type =
+            MsgTypes::try_from(tag).map_err(|_| binread::Error::NoVariantMatch { pos: 1 })?;
+
+        let m = match msg_type {
+            {{#each packets as |pkt|}}
+            MsgTypes::{{upper_camel pkt.name}} => Message::from({{upper_camel pkt.name}}::read_options(reader, options, args)?),
+            {{/each}}
+        };
+
+        Ok(m)
+    }
+}
+
+impl BinWrite for Message {
+    fn write_options<W: std::io::Write>(
+        &self,
+        writer: &mut W,
+        options: &binwrite::WriterOption,
+    ) -> std::io::Result<()> {
+        let tag = MsgTypes::get_tag_for(self);
+
+        tag.write_options(writer, options)?;
+
+        match self {
+            {{#each packets as |pkt|}}
+            Message::{{upper_camel pkt.name}}(m) => m.write(writer),
+            {{/each}}
+        }?;
+
+        Ok(())
+    }
+
+    fn write<W: std::io::Write>(&self, writer: &mut W) -> std::io::Result<()> {
+        self.write_options(writer, &binwrite::WriterOption::default())
+    }
+}
+
+ {{#each packets as |pkt|}}
+ impl From<{{upper_camel pkt.name}}> for Message {
+    fn from(value: {{upper_camel pkt.name}}) -> Self {
+        Message::{{upper_camel pkt.name}}(value)
+    }
+}
+  
+{{/each}}
+

--- a/src/targets/templates/rust/ramble.rs.hbs
+++ b/src/targets/templates/rust/ramble.rs.hbs
@@ -35,12 +35,11 @@ pub enum DeserializeError {
 #[derive(PartialEq, Debug, BinRead, BinWrite)]
 struct {{upper_camel pkt.name}} {
     {{#each pkt.fields as |field|}}
-    {{field.name}}: {{map_type field.field_type}}, 
+    {{field.name}}: {{map_type field.field_type}},
     {{/each}}
 }
 
 {{/each}}
-
 #[derive(Debug)]
 enum MsgTypes {
     {{#each packets as |pkt|}}
@@ -70,7 +69,6 @@ impl TryFrom<TagValue> for MsgTypes {
         }
     }
 }
-
 
 #[derive(Debug, PartialEq)]
 enum Message {
@@ -144,13 +142,11 @@ impl BinWrite for Message {
         self.write_options(writer, &binwrite::WriterOption::default())
     }
 }
+{{#each packets as |pkt|}}
 
- {{#each packets as |pkt|}}
- impl From<{{upper_camel pkt.name}}> for Message {
+impl From<{{upper_camel pkt.name}}> for Message {
     fn from(value: {{upper_camel pkt.name}}) -> Self {
         Message::{{upper_camel pkt.name}}(value)
     }
 }
-  
 {{/each}}
-


### PR DESCRIPTION
This PR adds a rust target code, there is still much work to get this to a usable state but meets the needs for now. 

**Notes**
Finding a serialization library that fit well proved harder than expected. `zerocopy` was an obvious choice however the had significant limitations on byte alignment. Ended up implementing a `serde` Serializer, before realizing that was a huge mistake. In the end went with `binread` which fits current needs well. 