### PR TITLE
Make integration tests more robust 

### DIFF
--- a/.github/workflows/cargo_build.yml
+++ b/.github/workflows/cargo_build.yml
@@ -19,7 +19,7 @@ jobs:
     name: Rust project
     runs-on: ubuntu-latest
     env:
-      GENERATED_DIRECTORY: ./tests/cpp
+      RAMBLE_GENERATED_DIRECTORY: ./tests/cpp
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
@@ -31,7 +31,7 @@ jobs:
           args: --release --all-features
 
       - name: Generate C++ Ramble files
-        run: ./target/release/ramble generate  --C -o "$GENERATED_DIRECTORY"
+        run: ./target/release/ramble generate  --C -o "$RAMBLE_GENERATED_DIRECTORY"
 
       - name: Install dependencies
         run: sudo apt-get update && sudo apt-get install -y build-essential cmake catch2
@@ -45,7 +45,7 @@ jobs:
         run: cmake --build .
 
       - name: Run tests with Catch2
-        run: ./tests/cpp/run_tests.sh "$GENERATED_DIRECTORY"
+        run: ./tests/cpp/run_tests.sh "$RAMBLE_GENERATED_DIRECTORY"
 
 
   clippy_check:

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ _deps
 CMakeUserPresets.json
 *.cmake
 *.tcl
+/tests/cpp/bin

--- a/tests/cpp/CMakeLists.txt
+++ b/tests/cpp/CMakeLists.txt
@@ -19,7 +19,6 @@ add_executable(tests test.cpp)
 target_link_libraries(tests PRIVATE Catch2::Catch2WithMain)
 target_include_directories(tests PRIVATE "$ENV{GENERATED_DIRECTORY}")
 
-message(STATUS ">>$ENV{GENERATED_DIRECTORY}")
 list(APPEND CMAKE_MODULE_PATH ${catch2_SOURCE_DIR}/extras)
 include(CTest)
 include(Catch)

--- a/tests/cpp/run_tests.sh
+++ b/tests/cpp/run_tests.sh
@@ -6,12 +6,12 @@ SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
 if [[ ! -z "$1" ]]; then
     # Expand passed in directory incase it was a relative path
-    # GENERATED_DIRECTORY is exported so it is available in CMAKE
-    export GENERATED_DIRECTORY="$(realpath $1)"
+    # RAMBLE_GENERATED_DIRECTORY is exported so it is available in CMAKE
+    export RAMBLE_GENERATED_DIRECTORY="$(realpath $1)"
 fi 
 
-if [[ -z "${GENERATED_DIRECTORY}" ]]; then
-    echo "envvar:GENERATED_DIRECTORY must be set before tests can be compiled; try passing it in."
+if [[ -z "${RAMBLE_GENERATED_DIRECTORY}" ]]; then
+    echo "envvar:RAMBLE_GENERATED_DIRECTORY must be set before tests can be compiled; try passing it in."
     exit 1
 fi
 
@@ -20,7 +20,7 @@ if [[ -z "${RAMBLE_TEST_DIR}" ]]; then
     RAMBLE_TEST_DIR=$SCRIPT_DIR
 fi 
 
-echo "Using GENERATED_DIRECTORY=$GENERATED_DIRECTORY"
+echo "Using RAMBLE_GENERATED_DIRECTORY=$RAMBLE_GENERATED_DIRECTORY"
 echo "Using RAMBLE_TEST_DIR=$RAMBLE_TEST_DIR"
 
 

--- a/tests/cpp/run_tests.sh
+++ b/tests/cpp/run_tests.sh
@@ -6,6 +6,7 @@ SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
 if [[ ! -z "$1" ]]; then
     # Expand passed in directory incase it was a relative path
+    # GENERATED_DIRECTORY is exported so it is available in CMAKE
     export GENERATED_DIRECTORY="$(realpath $1)"
 fi 
 
@@ -14,9 +15,17 @@ if [[ -z "${GENERATED_DIRECTORY}" ]]; then
     exit 1
 fi
 
-echo "Using GENERATED_DIRECTORY=$GENERATED_DIRECTORY"
+if [[ -z "${RAMBLE_TEST_DIR}" ]]; then
+    echo "assume SCRIPT"
+    RAMBLE_TEST_DIR=$SCRIPT_DIR
+fi 
 
-cmake $SCRIPT_DIR
+echo "Using GENERATED_DIRECTORY=$GENERATED_DIRECTORY"
+echo "Using RAMBLE_TEST_DIR=$RAMBLE_TEST_DIR"
+
+
+# ============== Build the Tests ================
+cmake $RAMBLE_TEST_DIR
 
 retVal=$?
 if [ $retVal -ne 0 ]; then
@@ -24,7 +33,7 @@ if [ $retVal -ne 0 ]; then
     exit $retVal
 fi
 export CMAKE_VERBOSE_MAKEFILE=True
-cmake --build  $SCRIPT_DIR
+cmake --build  $RAMBLE_TEST_DIR
 
 retVal=$?
 if [ $retVal -ne 0 ]; then
@@ -32,7 +41,9 @@ if [ $retVal -ne 0 ]; then
     exit $retVal
 fi
 
-$SCRIPT_DIR/bin/tests
+# ============== Run Test Binary ================
+
+$RAMBLE_TEST_DIR/bin/tests
 
 retVal=$?
 if [ $retVal -ne 0 ]; then

--- a/tests/cpp/run_tests.sh
+++ b/tests/cpp/run_tests.sh
@@ -1,8 +1,12 @@
 ###  This script builds and then runs the cpp tests
 ###  Invoke 'run_script.sh <PATH_TO_RAMBLE.HPP>'
 
+# Get script directory to get the correct directory to pass to cmake, regardless of where the script is executed from
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
 if [[ ! -z "$1" ]]; then
-    GENERATED_DIRECTORY=$1
+    # Expand passed in directory incase it was a relative path
+    export GENERATED_DIRECTORY="$(realpath $1)"
 fi 
 
 if [[ -z "${GENERATED_DIRECTORY}" ]]; then
@@ -12,18 +16,15 @@ fi
 
 echo "Using GENERATED_DIRECTORY=$GENERATED_DIRECTORY"
 
-cd ./tests/cpp/
-
-
-cmake .
+cmake $SCRIPT_DIR
 
 retVal=$?
 if [ $retVal -ne 0 ]; then
     echo "Failed to configure cmake" 
     exit $retVal
 fi
-
-cmake --build .
+export CMAKE_VERBOSE_MAKEFILE=True
+cmake --build  $SCRIPT_DIR
 
 retVal=$?
 if [ $retVal -ne 0 ]; then
@@ -31,7 +32,7 @@ if [ $retVal -ne 0 ]; then
     exit $retVal
 fi
 
-./bin/tests
+$SCRIPT_DIR/bin/tests
 
 retVal=$?
 if [ $retVal -ne 0 ]; then

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -13,7 +13,7 @@ fn run_cpp_tests() {
         .expect("bad code generation");
 
     let test_results = Command::new("bash")
-        .env("GENERATED_DIRECTORY", dest.path())
+        .env("RAMBLE_GENERATED_DIRECTORY", dest.path())
         .env("RUST_BACKTRACE", "full")
         .arg("-c")
         .arg(" ./tests/cpp/run_tests.sh")

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -3,19 +3,20 @@ use std::{path::PathBuf, process::Command};
 use tempfile::tempdir;
 
 #[test]
-fn cpp_build() {
+fn run_cpp_tests() {
     let data =
         load_ramble_file(PathBuf::from("tests/ramble.yaml")).expect("cannot load ramble.yaml");
     let dest = tempdir().expect("unable to create tempdir");
     let code_gen = CodeGenerator::new(dest.path());
-    let files = code_gen
+    let _ = code_gen
         .to_code::<TargetC>(&data)
         .expect("bad code generation");
-    println!("{:#?}", files);
 
-    let test_results = Command::new("sh")
+    let test_results = Command::new("bash")
+        .env("GENERATED_DIRECTORY", dest.path())
+        .env("RUST_BACKTRACE", "full")
         .arg("-c")
-        .arg(" ./tests/cpp/run_tests.sh ")
+        .arg(" ./tests/cpp/run_tests.sh")
         .output()
         .expect("failed to execute process");
 


### PR DESCRIPTION
This PR adds stability to the integration tests. Previously they had assumptions about where the tests were being run from, which led to errors due to incorrect paths. 

`cargo test` not runs the target integration tests, which makes it easier to run the tests locally.  