### PR TITLE
Jazzz/add primitives

### DIFF
--- a/ramble.yaml
+++ b/ramble.yaml
@@ -1,15 +1,15 @@
 # Example Ramble File
 ---
-version: "1"      # Required
+version: "1"              # Required
 namespace: thisnamespace
 packets:
-  - name: hello   # Required
+  - name: hello           # Required
     properties:
       - crc
     fields:
       - seq: u16
       - flags: u8
-  - name: primitive   # Required
+  - name: change_record   # Required
     fields:
       - record_id: u64
-      - record_value: u32
+      - record_value: i32

--- a/ramble.yaml
+++ b/ramble.yaml
@@ -1,4 +1,4 @@
-#Example Ramble File
+# Example Ramble File
 ---
 version: "1"      # Required
 namespace: thisnamespace
@@ -7,8 +7,9 @@ packets:
     properties:
       - crc
     fields:
-      - seq: u8 
-  - name: change_record   # Required
+      - seq: u16
+      - flags: u8
+  - name: primitive   # Required
     fields:
-      - record_id: u8
-      - record_value: u8
+      - record_id: u64
+      - record_value: u32

--- a/src/codegen/target_c.rs
+++ b/src/codegen/target_c.rs
@@ -26,6 +26,9 @@ impl Lang for TargetC {
     fn type_map(ft: &FieldType) -> &str {
         match ft {
             FieldType::Uint8T => "uint8_t",
+            FieldType::Uint16T => "uint16_t",
+            FieldType::Uint32T => "uint32_t",
+            FieldType::Uint64T => "uint64_t",
         }
     }
 

--- a/src/codegen/target_c.rs
+++ b/src/codegen/target_c.rs
@@ -29,6 +29,10 @@ impl Lang for TargetC {
             FieldType::Uint16T => "uint16_t",
             FieldType::Uint32T => "uint32_t",
             FieldType::Uint64T => "uint64_t",
+            FieldType::Sint8T => "int8_t",
+            FieldType::Sint16T => "int16_t",
+            FieldType::Sint32T => "int32_t",
+            FieldType::Sint64T => "int64_t",
         }
     }
 

--- a/src/codegen/target_rust.rs
+++ b/src/codegen/target_rust.rs
@@ -27,6 +27,10 @@ impl Lang for TargetRust {
             FieldType::Uint16T => "u16",
             FieldType::Uint32T => "u32",
             FieldType::Uint64T => "u64",
+            FieldType::Sint8T => "i8",
+            FieldType::Sint16T => "i16",
+            FieldType::Sint32T => "i32",
+            FieldType::Sint64T => "i64",
         }
     }
 

--- a/src/codegen/target_rust.rs
+++ b/src/codegen/target_rust.rs
@@ -24,6 +24,9 @@ impl Lang for TargetRust {
     fn type_map(ft: &FieldType) -> &str {
         match ft {
             FieldType::Uint8T => "u8",
+            FieldType::Uint16T => "u16",
+            FieldType::Uint32T => "u32",
+            FieldType::Uint64T => "u64",
         }
     }
 

--- a/src/config/packet.rs
+++ b/src/config/packet.rs
@@ -24,6 +24,9 @@ impl Packet {
 #[derive(Debug, Serialize, Deserialize)]
 pub enum FieldType {
     Uint8T,
+    Uint16T,
+    Uint32T,
+    Uint64T,
 }
 
 impl TryFrom<&str> for FieldType {
@@ -32,6 +35,9 @@ impl TryFrom<&str> for FieldType {
     fn try_from(value: &str) -> Result<Self> {
         match value {
             "Uint8T" => Ok(Self::Uint8T),
+            "Uint16T" => Ok(Self::Uint16T),
+            "Uint32T" => Ok(Self::Uint32T),
+            "Uint64T" => Ok(Self::Uint64T),
             _ => bail!("Unknown FieldType"),
         }
     }

--- a/src/config/packet.rs
+++ b/src/config/packet.rs
@@ -27,6 +27,10 @@ pub enum FieldType {
     Uint16T,
     Uint32T,
     Uint64T,
+    Sint8T,
+    Sint16T,
+    Sint32T,
+    Sint64T,
 }
 
 impl TryFrom<&str> for FieldType {
@@ -38,6 +42,10 @@ impl TryFrom<&str> for FieldType {
             "Uint16T" => Ok(Self::Uint16T),
             "Uint32T" => Ok(Self::Uint32T),
             "Uint64T" => Ok(Self::Uint64T),
+            "Sint8T" => Ok(Self::Uint8T),
+            "Sint16T" => Ok(Self::Uint16T),
+            "Sint32T" => Ok(Self::Uint32T),
+            "Sint64T" => Ok(Self::Uint64T),
             _ => bail!("Unknown FieldType"),
         }
     }

--- a/src/config/parse.rs
+++ b/src/config/parse.rs
@@ -89,6 +89,10 @@ impl Scanner {
                             "u16" => FieldType::Uint16T,
                             "u32" => FieldType::Uint32T,
                             "u64" => FieldType::Uint64T,
+                            "i8" => FieldType::Uint8T,
+                            "i16" => FieldType::Uint16T,
+                            "i32" => FieldType::Uint32T,
+                            "i64" => FieldType::Uint64T,
                             _ => return Err(ConfigError::InvalidFieldType(fts.into())),
                         };
 

--- a/src/config/parse.rs
+++ b/src/config/parse.rs
@@ -1,6 +1,4 @@
-use std::fmt::format;
-
-use log::{debug, info};
+use log::debug;
 use paris::warn;
 use yaml_rust2::Yaml::Hash;
 use yaml_rust2::{Yaml, YamlLoader};
@@ -85,8 +83,12 @@ impl Scanner {
                             format!("{:?}", field_type),
                         ))?;
 
+                        // TODO: remove duplicate code.
                         let ft = match fts {
                             "u8" => FieldType::Uint8T,
+                            "u16" => FieldType::Uint16T,
+                            "u32" => FieldType::Uint32T,
+                            "u64" => FieldType::Uint64T,
                             _ => return Err(ConfigError::InvalidFieldType(fts.into())),
                         };
 


### PR DESCRIPTION
This PR adds signed and unsigned integer types. Booleans, floating point numbers are purposely left for a future PR for simplicity. The tests of the target implementations needs to be reworked, anyways.

