### PR TITLE
Remove anyhow dependency from Lib

### DIFF
--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -1,3 +1,4 @@
+mod error;
 mod generate;
 mod target_c;
 mod target_rust;

--- a/src/codegen/error.rs
+++ b/src/codegen/error.rs
@@ -1,0 +1,15 @@
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum CodegenError {
+    #[error("program error: {0}")]
+    ProgramError(String),
+    #[error("io:{0}")]
+    IO(#[from] std::io::Error),
+    #[error("template could not be loaded: {0}")]
+    TemplateError(#[from] handlebars::TemplateError),
+    #[error("template could not be rendered: {0}")]
+    RenderError(#[from] handlebars::RenderError),
+    #[error("Unknown:{0}")]
+    Unknown(String),
+}

--- a/src/codegen/generate.rs
+++ b/src/codegen/generate.rs
@@ -1,14 +1,16 @@
-use anyhow::Result;
 use std::fs::{self, File};
 use std::io::Write;
 use std::path::{Path, PathBuf};
 
+use super::error::CodegenError;
 use super::FileObject;
 use crate::config::packet::{FieldType, RambleConfig};
 
+type ErrorType = CodegenError;
+
 pub trait Lang {
     fn type_map(ft: &FieldType) -> &str;
-    fn render_template(packets: &RambleConfig) -> Result<Vec<FileObject>>;
+    fn render_template(packets: &RambleConfig) -> Result<Vec<FileObject>, ErrorType>;
 }
 
 pub struct CodeGenerator<'a> {
@@ -20,7 +22,7 @@ impl<'a> CodeGenerator<'a> {
         CodeGenerator { dest }
     }
 
-    pub fn to_code<T: Lang>(&self, rfg: &RambleConfig) -> Result<Vec<PathBuf>> {
+    pub fn to_code<T: Lang>(&self, rfg: &RambleConfig) -> Result<Vec<PathBuf>, ErrorType> {
         // Call out to the target to generate the new files
         let file_objs = T::render_template(rfg)?;
 
@@ -35,7 +37,7 @@ impl<'a> CodeGenerator<'a> {
         Ok(written_files)
     }
 
-    fn save_file(&self, filename: &Path, content_str: &str) -> Result<()> {
+    fn save_file(&self, filename: &Path, content_str: &str) -> Result<(), ErrorType> {
         // Ensure entire path exists
         fs::create_dir_all(filename.parent().expect("invalid parent path"))?;
 

--- a/src/codegen/target_c.rs
+++ b/src/codegen/target_c.rs
@@ -1,4 +1,3 @@
-use anyhow::Context;
 use convert_case::{Case, Casing};
 use handlebars::handlebars_helper;
 use handlebars::{to_json, Handlebars, RenderErrorReason};
@@ -6,6 +5,7 @@ use serde_json::Map;
 use serde_json::Value;
 use std::path::PathBuf;
 
+use super::error::CodegenError;
 use super::generate::Lang;
 use super::FileObject;
 use crate::config::packet::{FieldType, RambleConfig};
@@ -36,7 +36,7 @@ impl Lang for TargetC {
         }
     }
 
-    fn render_template(rfg: &RambleConfig) -> anyhow::Result<Vec<FileObject>> {
+    fn render_template(rfg: &RambleConfig) -> Result<Vec<FileObject>, CodegenError> {
         // This makes the assumption that the hbs files are available to the binary at runtime, and is not a
         // sustainable solution. Currently this also requires that the executable is called from the project
         // root, so they relative path works.
@@ -44,14 +44,14 @@ impl Lang for TargetC {
 
         let filename = path
             .file_stem()
-            .context("unable to get filename from path")?
+            .ok_or(CodegenError::ProgramError("invalid template path".into()))?
             .to_os_string();
 
         let mut handlebars = Handlebars::new();
         handlebars.register_template_file(
             "src",
             path.to_str()
-                .context("Program Error: Check path variable ")?,
+                .ok_or(CodegenError::ProgramError("check template path".into()))?,
         )?;
 
         handlebars.register_helper("upper_camel", Box::new(upper_camel));

--- a/src/codegen/target_rust.rs
+++ b/src/codegen/target_rust.rs
@@ -1,4 +1,3 @@
-use anyhow::Context;
 use convert_case::{Case, Casing};
 use handlebars::handlebars_helper;
 use handlebars::{to_json, Handlebars, RenderErrorReason};
@@ -6,6 +5,7 @@ use serde_json::Map;
 use serde_json::Value;
 use std::path::PathBuf;
 
+use super::error::CodegenError;
 use super::generate::Lang;
 use super::FileObject;
 use crate::config::packet::{FieldType, RambleConfig};
@@ -34,19 +34,19 @@ impl Lang for TargetRust {
         }
     }
 
-    fn render_template(rfg: &RambleConfig) -> anyhow::Result<Vec<FileObject>> {
+    fn render_template(rfg: &RambleConfig) -> Result<Vec<FileObject>, CodegenError> {
         let path = PathBuf::from("src/codegen/templates/rust/ramble.rs.hbs");
 
         let filename = path
             .file_stem()
-            .context("unable to get filename from path")?
+            .ok_or(CodegenError::ProgramError("invalid template path".into()))?
             .to_os_string();
 
         let mut handlebars = Handlebars::new();
         handlebars.register_template_file(
             "src",
             path.to_str()
-                .context("Program Error: Check path variable ")?,
+                .ok_or(CodegenError::ProgramError("check template path".into()))?,
         )?;
 
         handlebars.register_helper("upper_camel", Box::new(upper_camel));

--- a/src/config/packet.rs
+++ b/src/config/packet.rs
@@ -1,6 +1,7 @@
-use anyhow::{bail, Result};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+
+use super::error::ConfigError;
 
 #[derive(Debug, Serialize)]
 pub struct Packet {
@@ -35,9 +36,9 @@ pub enum FieldType {
 }
 
 impl TryFrom<&str> for FieldType {
-    type Error = anyhow::Error;
+    type Error = ConfigError;
 
-    fn try_from(value: &str) -> Result<Self> {
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
         match value {
             "U8" => Ok(Self::U8),
             "U16" => Ok(Self::U16),
@@ -47,7 +48,7 @@ impl TryFrom<&str> for FieldType {
             "I16" => Ok(Self::I16),
             "I32" => Ok(Self::I32),
             "I64" => Ok(Self::I64),
-            _ => bail!("Unknown FieldType"),
+            _ => Err(ConfigError::InvalidFieldType(value.into())),
         }
     }
 }

--- a/src/config/parse.rs
+++ b/src/config/parse.rs
@@ -83,8 +83,7 @@ impl Scanner {
                             format!("{:?}", field_type),
                         ))?;
 
-                        let ft = FieldType::try_from(fts)
-                            .map_err(|e| ConfigError::InvalidFieldType(fts.into()))?;
+                        let ft = FieldType::try_from(fts)?;
 
                         pkt.add_field(Field::new(ids.into(), ft));
                     }


### PR DESCRIPTION
This PR creates explicit thiserror::Errors for all calls in the crate. Anyhow was left over from when ramble was only a binary, and has now been removed. Anyhow is still a dependency of the binary for now for simplicity. 

The binary will likely be moved to its own crate in the future, which would separate the binary's dependency from that of the library crate. 