### PR TITLE
Cleanup parsing of ramble file

### DIFF
--- a/src/config/error.rs
+++ b/src/config/error.rs
@@ -14,6 +14,8 @@ pub enum ConfigError {
     BadYaml(#[from] yaml_rust2::ScanError),
     #[error("file contains unexpected data: {0}")]
     BadFormat(String),
-    #[error("unexpected type for {0}. expected:{1} found:{2} ")]
-    UnexpectedType(String, String, String),
+    #[error("program error(this should not have been possible): {0}")]
+    ProgramError(String),
+    #[error("unexpected type: expected:{0} found:{1} ")]
+    UnexpectedType(String, String),
 }

--- a/src/config/packet.rs
+++ b/src/config/packet.rs
@@ -63,6 +63,13 @@ impl Field {
     pub fn new(name: String, field_type: FieldType) -> Self {
         Field { name, field_type }
     }
+
+    pub fn try_from_config(field_id: &str, field_type: &str) -> Result<Self, ConfigError> {
+        Ok(Field::new(
+            field_id.into(),
+            FieldType::try_from(field_type)?,
+        ))
+    }
 }
 
 #[derive(Debug, Serialize)]


### PR DESCRIPTION
This PR cleans up how the packet definitions were being parsed from the ramble file. It reduces some complexity by by adding some helper functions, for YAML conversions. Still not happy with it, but this will all get replaced soon. 

The parsing process iteratively builds the intermediate form by appending definitions as they are parsed. This makes testing annoy, and I'd rather construct the objects once, all the children have been constructed. Not critical at this moment, so deferring for now.