### PR TITLE
Fix lint workflow

### DIFF
--- a/.github/workflows/cargo_build.yml
+++ b/.github/workflows/cargo_build.yml
@@ -1,4 +1,4 @@
-name: Test(Cargo)
+name: Test(Ramble)
 
 on:
   push:
@@ -34,12 +34,3 @@ jobs:
         with:
           command: test
           args: --lib --bins
-
-
-  clippy_check:
-    name: Lint
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Run Clippy
-        run: cargo clippy --all-targets --all-features

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,20 @@
+name: Lint(Clippy)
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+env:
+  RUSTFLAGS: "-Dwarnings"
+
+jobs:
+  clippy_check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run Clippy
+        run: cargo clippy --all-targets --all-features

--- a/src/config/parse.rs
+++ b/src/config/parse.rs
@@ -1,12 +1,10 @@
-use std::fmt::format;
-
 use log::debug;
 use paris::warn;
 use yaml_rust2::Yaml::Hash;
 use yaml_rust2::{Yaml, YamlLoader};
 
 use super::error::ConfigError;
-use super::packet::{Field, FieldType, Packet, RambleConfig};
+use super::packet::{Field, Packet, RambleConfig};
 
 const KEY_PACKETS: &str = "packets";
 const KEY_NAME: &str = "name";


### PR DESCRIPTION
The compiler flag to error on warnings was not configured for the linter flow. This PR enables -Dwarnings and moved the lint job to its own workflow so its easier to follow